### PR TITLE
Clarify Content Security Policy and allow external HTTPS fetches

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -11,8 +11,8 @@ server {
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
     
     # Content Security Policy
-    # Allows: self-hosted scripts/styles, inline scripts (TanStack hydration), Google Fonts, and data: for SVG images
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self'; frame-ancestors 'self'; base-uri 'self'; form-action 'self';" always;
+    # Allows: self-hosted scripts/styles, inline scripts (TanStack hydration), Google Fonts, external HTTPS fetch (load from URL), and data: for SVG images
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https:; frame-ancestors 'self'; base-uri 'self'; form-action 'self';" always;
     
     # Strict-Transport-Security (HSTS) - Enable when using HTTPS
     # Uncomment the line below if serving over HTTPS


### PR DESCRIPTION
Update the Content Security Policy comment for better clarity and include support for external HTTPS fetches in the policy itself.